### PR TITLE
Add AWK

### DIFF
--- a/markdowns/bash.md
+++ b/markdowns/bash.md
@@ -73,6 +73,16 @@ _Note: using `python` instead of `python3` saves 1 char, but it still invokes Py
 My Ruby solution is 34 chars.
 Currently `ruby` seems to be not in the `$PATH` on CG, so we need to add full path which costs 24 chars for invoking the interpreter.
 
+## +1 bonus: AWK
+
+```sh
+# ===== to AWK from Bash
+#   length = 6 + base [30] = 36 chars
+awk '{print $1==1?1:6*$1*($1-2)+8}'
+```
+
+This solution is 30 chars. Calling the interpreter adds 6 chars.
+
 ## Coming next...
 
 Starting from `bash` is not always what we need. How to do similar system calls from other languages?

--- a/markdowns/versions.md
+++ b/markdowns/versions.md
@@ -67,6 +67,8 @@ printf "Node.js " >&2 ; /opt/coderunner/nodejs/bin/node --version >&2
 printf "Typescript Compiler " >&2 ; /opt/coderunner/nodejs/bin/node /opt/coderunner/typescript/tsc/node_modules/typescript/bin/tsc --version | head -2 | tail -1 >&2
 echo "=== VB.NET ===" >&2
 printf ".NET " >&2 ; /opt/coderunner/dotnet/sdk/dotnet --version | head -1 >&2
+echo "=== EXTRA: AWK ===" >&2
+awk -W version >&2
 echo "=== EXTRA: COBOL ===" >&2
 /opt/coderunner/cobol/bin/cobc --version | head -1 >&2
 echo "=== EXTRA: FORTRAN ===" >&2
@@ -135,6 +137,12 @@ Node.js v16.14.2
 Typescript Compiler Version 4.6.3
 === VB.NET ===
 .NET 6.0.401
+=== EXTRA: AWK ===
+mawk 1.3.3 Nov 1996, Copyright (C) Michael D. Brennan
+
+compiled limits:
+max NF             32767
+sprintf buffer      2040
 === EXTRA: COBOL ===
 cobc (GnuCOBOL) 3.1.2.0
 === EXTRA: FORTRAN ===


### PR DESCRIPTION
Hey there, I came across your playground on CodinGame and as a fellow polyglot programming enjoyer, and I really loved the things you came up with here. Thanks for putting it out into the world

If it's ok I'd also like to add [AWK](https://awk.dev/) to the mix. While it's most commonly used for text manipulation, it's also a fully turing-complete language and I feel like worth including

I also added the version, as it can occasionally be important (especially when golfing) to know if you're using gawk/mawk/one-true-awk/etc

_Note: I am assuming/pretending that the version of `mawk` installed in CodinGame runners has not changed since July '24. I would be happy for a time traveler to prove me wrong._